### PR TITLE
Comply with axe-core 2.2

### DIFF
--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -39,7 +39,11 @@
     </form>
   {{/if}}
 
-  <button class="navbar-toggler ember-view" onclick={{action "toggleMenu"}} aria-label="Open navigation">
+  <button
+    class="navbar-toggler ember-view"
+    onclick={{action "toggleMenu"}}
+    aria-label="Open navigation"
+  >
     <span class="navbar-toggler-icon"></span>
   </button>
 </div>

--- a/addon/components/es-navbar/template.hbs
+++ b/addon/components/es-navbar/template.hbs
@@ -39,7 +39,7 @@
     </form>
   {{/if}}
 
-  <button class="navbar-toggler ember-view" onclick={{action "toggleMenu"}}>
+  <button class="navbar-toggler ember-view" onclick={{action "toggleMenu"}} aria-label="Open navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 </div>


### PR DESCRIPTION
https://dequeuniversity.com/rules/axe/2.2/button-name?application=lighthouse

Address automated audit failure about empty button with no contents.

We could improve this further, but we have no reason not to at least add a label here.